### PR TITLE
Remove global gatsby install

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,5 @@ We are building a tool to help retirees affected by the Social Security Windfall
 Join the Slack channel #windfall-elimination for more information.
 
 ## Launching Gatsby Site
-Install the gatsby-cli with `npm install -g gatsby-cli`
 
-Run `npm install && gatsby develop` to launch the project.
+Run `npm install && npx gatsby develop` to launch the project.


### PR DESCRIPTION
As [Gatsby is installed as a local dependency](https://github.com/codeforboston/windfall-elimination/blob/master/package.json#L16-L17), we can [call the local gatsby binary](https://blog.npmjs.org/post/162869356040/introducing-npx-an-npm-package-runner) already inside the project and remove the need for a globally installed CLI.