### PR TITLE
Contextual Month/Year pickers & make radiobutton UX match design

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -27,7 +27,7 @@ import InfoWidget from "./info-widget";
 import FontLayout from "./font-layout";
 import FontPad from "./font-pad";
 import { PrintButton } from "./print-button";
-import { RadioButton, AnswerBox, AnswerInput } from './radio-button';
+import { RadioButton, AnswerBox, LabelText, AnswerInput } from './radio-button';
 import Glossary from './glossary';
 
 export {
@@ -61,6 +61,7 @@ export {
     FontPad,
     PrintButton,
     RadioButton,
+    LabelText,
     AnswerBox,
     AnswerInput,
     Glossary 

--- a/src/components/radio-button.tsx
+++ b/src/components/radio-button.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 import { colors } from "../constants";
+import { ClassNames } from "@emotion/core";
 
 export const RadioButton = styled.input`
   -webkit-appearance: none;
@@ -15,14 +16,60 @@ export const RadioButton = styled.input`
   border-radius: 50%;
 
   &:checked {
-    border: 13px solid ${colors.purple};
+    border: 3px solid ${colors.white};
     border-radius: 100px;
     color: ${colors.white};
-    background-color: ${colors.white};
+    background-color: ${colors.purple};
+
+    &:after {
+      content: ' ';
+      height: 15px;
+      width: 10px;
+      background-color: #fff;
+      padding-left: 5px;
+      margin-left: 8px;
+      border: 2px solid #FFF;
+      border-radius: 100px;
+      margin-top: 7px;
+      display: inline-block;
+   }
   }
+
 `;
 
-export const AnswerBox = styled.div`
+/* Look for radiobuttons inside this component that have checked children and set a special class */
+export const AnswerBoxBasic = ({ className, children, ...props }) => {
+  const hasCheckedChildren =
+    children.filter(n => n.props.checked === "true" || n.props.checked === true)
+      .length > 0;
+
+  return (
+    <ClassNames>
+      {({ css, cx }) => (
+        <label
+          {...props}
+          className={[
+            className || "",
+            hasCheckedChildren &&
+              css`
+                background-color: ${colors.purple};
+                color: #FFF;
+              `
+          ].join(" ")}
+        >
+          {children}
+        </label>
+      )}
+    </ClassNames>
+  );
+};
+
+export const LabelText = styled.span`
+  font-size: 30px;
+`;
+
+
+export const AnswerBox = styled(AnswerBoxBasic)`
   border: 2px solid ${colors.purple};
   height: 60px;
   font-size: 30px;

--- a/src/pages/prescreen-1a.tsx
+++ b/src/pages/prescreen-1a.tsx
@@ -82,6 +82,8 @@ export default class Prescreen1c extends React.Component {
                     id="birthDatePicked"
                     placeholderText="Click to select a date"
                     selected={this.state.birthDate}
+                    showYearDropdown
+                    openToDate={new Date("1960/01/01")}
                     onChange={(value) => this.handleDateChange("birthDatePicked", value)}
                     />
                   </Card>                  
@@ -91,6 +93,8 @@ export default class Prescreen1c extends React.Component {
                     id="retireDatePicked"
                     placeholderText="Click to select a date"
                     selected={this.state.retireDate}
+                    showMonthYearPicker
+                    openToDate={new Date("2018/01/01")}
                     onChange={(value) => this.handleDateChange("retireDatePicked", value)}
                     />
                   </Card>

--- a/src/pages/prescreen-1b.tsx
+++ b/src/pages/prescreen-1b.tsx
@@ -11,6 +11,7 @@ import {
   TextBlock,
   FileUpload,
   RadioButton,
+  LabelText,
   AnswerBox,
   Glossary
 } from "../components";
@@ -21,10 +22,6 @@ export const SsaImage= styled("img")`
   border: 1px solid #dddddd;
   width: 500px;
   margin-top: 25px;
-`;
-
-const Label = styled.label`
-  font-size: 30px;
 `;
 
 const HowToContainer = styled.div`
@@ -74,6 +71,7 @@ export default class Prescreen1b extends React.Component {
     }
 
     handleOption(e) {
+    
         SessionStore.push(e.target.name, e.target.value)
         this.setState({[e.target.name]: e.target.value})
     }
@@ -106,11 +104,11 @@ export default class Prescreen1b extends React.Component {
                     <QuestionText>Do you have a copy of your earnings record?</QuestionText>
                     <AnswerBox>
                     <RadioButton type="radio" name="haveEarnings" value="true" onChange={this.handleOption} checked={this.state.haveEarnings === 'true' } />
-                    <Label>Yes</Label> 
+                    <LabelText>Yes</LabelText> 
                     </AnswerBox>
                     <AnswerBox>
                     <RadioButton type="radio" name="haveEarnings" value="false" onChange={this.handleOption} checked={this.state.haveEarnings === 'false' } />
-                    <Label>No</Label>
+                    <LabelText>No</LabelText>
                     </AnswerBox>
                 </Card>
 
@@ -119,19 +117,19 @@ export default class Prescreen1b extends React.Component {
                 <QuestionText>What format is the copy of your earnings record?</QuestionText>
                 <AnswerBox>
                   <RadioButton type="radio" name="earningsFormat" value={EarningsEnum.XML} onChange={this.handleOption} checked={this.state.earningsFormat === EarningsEnum.XML} />
-                  <Label>XML file (MySocialSecurity)</Label>
+                  <LabelText>XML file (MySocialSecurity)</LabelText>
                 </AnswerBox>
                 <AnswerBox>
                   <RadioButton type="radio" name="earningsFormat" value={EarningsEnum.PDF} onChange={this.handleOption} checked={this.state.earningsFormat === EarningsEnum.PDF} />
-                  <Label>PDF (MySocialSecurity)</Label>
+                  <LabelText>PDF (MySocialSecurity)</LabelText>
                 </AnswerBox>
                 <AnswerBox>
                   <RadioButton type="radio" name="earningsFormat" value={EarningsEnum.PDFPRINT} onChange={this.handleOption} checked={this.state.earningsFormat === EarningsEnum.PDFPRINT} />
-                  <Label>PDF (scanned from print)</Label>
+                  <LabelText>PDF (scanned from print)</LabelText>
                 </AnswerBox>
                 <AnswerBox>
                   <RadioButton type="radio" name="earningsFormat" value={EarningsEnum.PAPER} onChange={this.handleOption} checked={this.state.earningsFormat === EarningsEnum.PAPER} />
-                  <Label>Paper (mailed from SSA)</Label>
+                  <LabelText>Paper (mailed from SSA)</LabelText>
                 </AnswerBox>
               </Card> : null
             }
@@ -141,11 +139,11 @@ export default class Prescreen1b extends React.Component {
                 <QuestionText>Do you have a MySocialSecurity account?</QuestionText>
                 <AnswerBox>
                   <RadioButton type="radio" name="haveSSAccount" value="true" onChange={this.handleOption} checked={this.state.haveSSAccount === 'true'} />
-                  <Label>Yes</Label>
+                  <LabelText>Yes</LabelText>
                 </AnswerBox>
                 <AnswerBox>
                   <RadioButton type="radio" name="haveSSAccount" value="false" onChange={this.handleOption} checked={this.state.haveSSAccount === 'false'} />
-                  <Label>No</Label>
+                  <LabelText>No</LabelText>
                 </AnswerBox>
               </Card> : null
             }

--- a/src/pages/prescreen-1c.tsx
+++ b/src/pages/prescreen-1c.tsx
@@ -11,6 +11,7 @@ import {
   SEO,
   RadioButton,
   AnswerBox, 
+  LabelText,
   Glossary,
   AnswerInput
 } from "../components";
@@ -140,7 +141,7 @@ export default class Prescreen1c extends React.Component {
                 {...(this.state.coveredEmployment ? { checked: true } : { checked: false })}
                 onChange={this.handleSelection}
               />
-              Yes
+              <LabelText>Yes</LabelText>
             </AnswerBox>
             <AnswerBox>
               <RadioButton
@@ -153,7 +154,7 @@ export default class Prescreen1c extends React.Component {
                   : { checked: false })}
                 onChange={this.handleSelection}
               />
-              No  
+              <LabelText>No</LabelText>
               </AnswerBox>
           </Card>
           {this.state.coveredEmployment && (
@@ -171,7 +172,7 @@ export default class Prescreen1c extends React.Component {
                     : { checked: false })}
                   onChange={this.handleSelection}
                 />
-                Yes
+                <LabelText>Yes</LabelText>
                 </AnswerBox>
                 <AnswerBox>
                 
@@ -184,7 +185,7 @@ export default class Prescreen1c extends React.Component {
                     : { checked: false })}
                   onChange={this.handleSelection}
                 />
-                No
+                <LabelText>No</LabelText>
                 </AnswerBox>
             </Card>
           )}
@@ -204,7 +205,7 @@ export default class Prescreen1c extends React.Component {
                     : { checked: false })}
                   onChange={this.handleSelection}
                 />
-                Monthly Pension
+                <LabelText>Monthly Pension</LabelText>
               </AnswerBox>
               <AnswerBox>
                 <RadioButton
@@ -216,7 +217,7 @@ export default class Prescreen1c extends React.Component {
                     : { checked: false })}
                   onChange={this.handleSelection}
                 />
-                Lump Sum
+                <LabelText>Lump Sum</LabelText>
                 </AnswerBox>
             </Card>
           )}


### PR DESCRIPTION
<img width="307" alt="image" src="https://user-images.githubusercontent.com/283343/66995848-aa58f880-f09d-11e9-958a-1e65d8699c7d.png">

<img width="325" alt="image" src="https://user-images.githubusercontent.com/283343/66995869-b04ed980-f09d-11e9-9024-2148be3b365b.png">

For radio buttons, I based the `<AnswerBox>` off of a `label` instead of a `div` which allows clicks to forward to the `<input/>`! `<Label>` is now based off a `span` and is renamed to `<LabelText>`.
<img width="460" alt="image" src="https://user-images.githubusercontent.com/283343/66995746-82699500-f09d-11e9-99f4-dbfe775970b3.png">

- [ ] TODO: put relative dates instead of absolute dates in birth & retirement date pickers using dayjs.
This PR closes #83