### PR TITLE
Add the ability to try out different retirement dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gatsby-transformer-sharp": "^2.1.17",
     "pdfjs-dist": "2.1.266",
     "prop-types": "^15.7.2",
+    "rc-slider": "^8.7.1",
     "react": "^16.8.5",
     "react-datepicker": "^2.9.6",
     "react-dom": "^16.8.5",
@@ -38,6 +39,7 @@
     "windfall-awareness-notebook-prototype": "https://api.observablehq.com/@thadk/windfall-awareness-notebook-prototype.tgz?v=1"
   },
   "devDependencies": {
+    "@types/rc-slider": "^8.6.5",
     "@types/react": "^16.8.8",
     "@types/react-dom": "^16.8.3",
     "babel-jest": "^24.9.0",

--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -71,13 +71,19 @@ export default class Screen2 extends React.Component {
     }
 
     async performCalc(){
-        var userDOR = new Date(JSON.parse(SessionStore.get("RetireDate"))).toLocaleDateString("en-US")
+      var userDOB = new Date(JSON.parse(SessionStore.get("BirthDate"))).toLocaleDateString("en-US")
+      var userDOR = new Date(JSON.parse(SessionStore.get("RetireDate"))).toLocaleDateString("en-US")
         var userCalc = await this.computeUserCalc(userDOR)
         SessionStore.push("UserProfile", JSON.stringify(userCalc))
+
         this.setState({
             isLoaded: true,
             userProfile: userCalc
         })
+
+        var yearsDiff = dayjs(userDOR).year() - dayjs(userDOB).year()
+        yearsDiff = yearsDiff < 62 ? 62 : yearsDiff > 70 ? 70 : yearsDiff
+        this.handleRetireChange(yearsDiff)
     }
 
     async handleRetireChange(value) {
@@ -106,13 +112,18 @@ export default class Screen2 extends React.Component {
                   </Card>
                  </>
                  }
-                {this.state.error ? null:
+                {this.state.testAge ?
                 <>
                 <HelperText>
                   However, Social Security changes your monthly benefit amount if you retire before or after your full retirement age. 
                   Use the slider below to see how your planned date of retirement will affect your monthly benefit amount.
                 </HelperText>
                 <Slider
+                  style = {{
+                    marginTop: 60,
+                    marginBottom: 60
+                  }}
+                  defaultValue = {this.state.testAge}
                   min={62} max={70}
                   marks=
                   {{
@@ -134,7 +145,7 @@ export default class Screen2 extends React.Component {
                   handleStyle={{
                     borderRadius: 0,
                     height: 24,
-                    width: 10,
+                    width: 15,
                     marginTop: -10,
                     backgroundColor: colors.purple,
                     boxShadow: '0 0 0 0',
@@ -145,15 +156,11 @@ export default class Screen2 extends React.Component {
                   railStyle={{ backgroundColor: colors.gray }}
                   onAfterChange={this.handleRetireChange}
                 />
-                {
-                  this.state.testAge ?
-                  <Card>
-                  Monthly benefit at age { this.state.testAge }:
-                  <p><strong><code>${this.state.testProfile["MPB"]} per month</code></strong></p>
-                  </Card>
-                  : null
-                }
-                </>
+                <Card>
+                Monthly benefit at age { this.state.testAge }:
+                <p><strong><code>${this.state.testProfile && this.state.testProfile["MPB"]} per month</code></strong></p>
+                </Card>
+                </> : null
                 }
                 <ButtonContainer>
                 <ButtonLink to="/print/" disabled={this.state.error}>Print Results</ButtonLink>

--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -3,6 +3,13 @@ import styled from "@emotion/styled";
 import { ButtonLink, SEO, H2, Card, Message, HelperText, Glossary } from "../components";
 import * as ObsFuncs from "../library/observable-functions";
 import { SessionStore } from "../library/session-store";
+import { colors } from "../constants";
+
+
+import Slider, { Range } from 'rc-slider';
+import 'rc-slider/assets/index.css';
+import dayjs from "dayjs";
+
 
 const ContentContainer = styled.div`
   max-width: 70%;
@@ -32,7 +39,11 @@ export default class Screen2 extends React.Component {
             isLoaded: false,
             userProfile: {}
         }
-    }
+
+        this.handleRetireChange = this.handleRetireChange.bind(this);
+        this.computeUserCalc = this.computeUserCalc.bind(this);
+
+      }
 
     componentDidMount(){
         if(!this.state.isLoaded){
@@ -43,36 +54,42 @@ export default class Screen2 extends React.Component {
         }
     }
 
+    async computeUserCalc(userDOR) {
+      var earnings = JSON.parse(SessionStore.get("earnings"))['osss:OnlineSocialSecurityStatementData']['osss:EarningsRecord']['osss:Earnings']
+      var userYSE = ObsFuncs.getYearsSE(earnings)
+      var year62 = JSON.parse(SessionStore.get("Year62"))
+      var userDOB = new Date(JSON.parse(SessionStore.get("BirthDate"))).toLocaleDateString("en-US")
+      if (SessionStore.get("coveredEmployment") && SessionStore.get("pensionOrRetirementAccount")) {
+        let userWEP = true;
+      } else {
+          let userWEP = false;
+      }
+      var userPension = Number(SessionStore.get("pensionAmount"))
+      var userAIME = ObsFuncs.getAIMEFromEarnings(earnings, year62)
+      var userCalc = await ObsFuncs.finalCalculation(userDOB, userDOR, year62, userYSE, userPension, userAIME)
+      return userCalc
+    }
+
     async performCalc(){
-        var earnings = JSON.parse(SessionStore.get("earnings"))['osss:OnlineSocialSecurityStatementData']['osss:EarningsRecord']['osss:Earnings']
-
-        var userYSE = ObsFuncs.getYearsSE(earnings)
-
-        var year62 = JSON.parse(SessionStore.get("Year62"))
-
-        var userDOB = new Date(JSON.parse(SessionStore.get("BirthDate"))).toLocaleDateString("en-US")
-
         var userDOR = new Date(JSON.parse(SessionStore.get("RetireDate"))).toLocaleDateString("en-US")
-
-        if (SessionStore.get("coveredEmployment") && SessionStore.get("pensionOrRetirementAccount")) {
-            let userWEP = true;
-        } else {
-            let userWEP = false;
-        }
-
-        var userPension = Number(SessionStore.get("pensionAmount"))
-
-        var userAIME = ObsFuncs.getAIMEFromEarnings(earnings, year62)
-
-        var userCalc = await ObsFuncs.finalCalculation(userDOB, userDOR, year62, userYSE, userPension, userAIME)
-
+        var userCalc = await this.computeUserCalc(userDOR)
         SessionStore.push("UserProfile", JSON.stringify(userCalc))
-
         this.setState({
             isLoaded: true,
             userProfile: userCalc
         })
     }
+
+    async handleRetireChange(value) {
+      var userDOB = new Date(JSON.parse(SessionStore.get("BirthDate"))).toLocaleDateString("en-US")
+      var userDOR = dayjs(userDOB).add(value, 'years').toDate()
+      var userCalc = await this.computeUserCalc(userDOR)
+      this.setState({
+        testAge: value,
+        testProfile: userCalc
+      })
+    }
+
 
     render() {
         return(
@@ -80,15 +97,64 @@ export default class Screen2 extends React.Component {
                 <SEO title="Screen 2" />
                 <ContentContainer>
                 <H2>Results</H2>  
-                {this.state.error?<label>Please go back and fill out all information to calculate results. </label>: <label>
-                    WEP calculated values
-                        <HelperText>Based on the information you provided, your retirement benefits will be calculated by Social Security as follows: </HelperText>
-                        <strong><code>${this.state.userProfile["MPB"] || null} per month</code></strong>
-                 </label> }
-                {this.state.error ? null: <Card>
+                {this.state.error?<label>Please go back and fill out all information to calculate results. </label>:
+                <>
+                 <HelperText>Based on the information you provided, your retirement benefits will be calculated by Social Security as follows: </HelperText>
+                 <Card>
+                  Monthly benefit at full retirement age:
+                  <p><strong><code>${this.state.userProfile["MPB"] || null} per month</code></strong></p>
+                  </Card>
+                 </>
+                 }
+                {this.state.error ? null:
+                <>
+                <HelperText>
                   However, Social Security changes your monthly benefit amount if you retire before or after your full retirement age. 
                   Use the slider below to see how your planned date of retirement will affect your monthly benefit amount.
-                </Card>}
+                </HelperText>
+                <Slider
+                  min={62} max={70}
+                  marks=
+                  {{
+                    62:{
+                      label: <strong>62</strong>,
+                      style: {
+                        color: colors.black,
+                      }
+                    },
+                    70:{
+                      label: <strong>70</strong>,
+                      style: {
+                        color: colors.black,
+                      }
+                    }
+                  }}
+                  step={1}
+                  trackStyle={{ backgroundColor: colors.gray }}
+                  handleStyle={{
+                    borderRadius: 0,
+                    height: 24,
+                    width: 10,
+                    marginTop: -10,
+                    backgroundColor: colors.purple,
+                    boxShadow: '0 0 0 0',
+                    borderColor: 'transparent'
+                  }}
+                  dotStyle={{ visibility: 'hidden' }}
+                  activeDotStyle={{ visibility: 'hidden' }}
+                  railStyle={{ backgroundColor: colors.gray }}
+                  onAfterChange={this.handleRetireChange}
+                />
+                {
+                  this.state.testAge ?
+                  <Card>
+                  Monthly benefit at age { this.state.testAge }:
+                  <p><strong><code>${this.state.testProfile["MPB"]} per month</code></strong></p>
+                  </Card>
+                  : null
+                }
+                </>
+                }
                 <ButtonContainer>
                 <ButtonLink to="/print/" disabled={this.state.error}>Print Results</ButtonLink>
                 </ButtonContainer>


### PR DESCRIPTION
Add a slider to the results page so users can try out difference retirement dates.

Refactor the performCalc function so that it can be used for both the initial result computation as well as adjusted retirement date computations.