### PR TITLE
Fix retirement dates in tests

### DIFF
--- a/src/test/Observable.test.js
+++ b/src/test/Observable.test.js
@@ -13,7 +13,7 @@ describe("John Q. Public (Full Retirement)", () => {
 
 	const earnings = fullRetirementValues['osss:OnlineSocialSecurityStatementData']['osss:EarningsRecord']['osss:Earnings'];
 	const userDOB = new Date("1947-10-10");
-	const userDOR = new Date("2013-10-10").toLocaleDateString("en-US"); // 66 is their full retirement age
+	const userDOR = new Date("2013-10-10"); // 66 is their full retirement age
 	const year62 = "2009";
 	const rawEarnings = getRawEarnings(earnings)
 	const userYSE = getYearsSE(rawEarnings);
@@ -22,7 +22,7 @@ describe("John Q. Public (Full Retirement)", () => {
 
 	it("Correctly tallies years of substantial earnings from a full earnings record.", async () => {
 		expect.assertions(1);
-		
+
 		expect(userYSE).toBe(30)
 	})
 
@@ -42,7 +42,9 @@ describe("John Q. Public (Full Retirement)", () => {
 	   	var userCalc = await finalCalculation(userDOB, userDOR, year62, userYSE, userPension, userAIME)
 
 		/* detailed calculator says 1,595.10 while observable says 1514.08, XML said 1811.00 (likely flawed)  */
-	    expect(Number(userCalc["MPB"])).toBe(1514.08)
+    /* Right now the test returns 1514.09 rather than 1514.08 like observable
+    Look in the one cent later to do  in some versions of node */
+      expect(Number(userCalc["MPB"])).toBe(1514.08)
 	 })
 
 	/* it("Correctly calculates Payable Benefit from a full earnings record (best, XML may be flawed)", async () => {
@@ -52,17 +54,17 @@ describe("John Q. Public (Full Retirement)", () => {
 
 		  var userCalc = await finalCalculation(userDOB, userDOR, year62, userYSE, userPension, userAIME)
 
-		// detailed calculator says 1,595.10 while observable says 1514.08, XML said 1811.00 (likely flawed) 
+		// detailed calculator says 1,595.10 while observable says 1514.08, XML said 1811.00 (likely flawed)
 		expect(Number(userCalc["MPB"])).toBe(1595.10)
 	}) */
 })
 
 describe("Sample 20 AnyPIA (Full Retirement)", () => {
-	
-	//Background finance info for Sample20 
+
+	//Background finance info for Sample20
 	const earnings = sample20RetirementValues['osss:OnlineSocialSecurityStatementData']['osss:EarningsRecord']['osss:Earnings'];
 	const userDOB = new Date("1952-06-22");
-	const userDOR = new Date("2018-07-22").toLocaleDateString("en-US"); // 66yo is their full retirement age.
+	const userDOR = new Date("2018-06-22"); // 66yo is their full retirement age.
 	const year62 = "2014";
 	const rawEarnings = getRawEarnings(earnings)
 	const userYSE = getYearsSE(rawEarnings);
@@ -70,14 +72,14 @@ describe("Sample 20 AnyPIA (Full Retirement)", () => {
 
 	it("Correctly tallies years of substantial earnings from a full earnings record.", async () => {
 		expect.assertions(1);
-		
+
 		expect(userYSE).toBe(22)
 	})
 
 	//Test AIME calculations
 	it("Correctly calculates getAIMEFromEarnings from a full earnings record.", async () => {
 		expect.assertions(1);
-	    
+
 	  	var AIME = await getAIMEFromEarnings(rawEarnings, 2014)
 
 	    expect(AIME).toBe(3403)


### PR DESCRIPTION
Fix specified full retirement dates in tests- they didn't match the way
the webapp formula calculated them.