### PR TITLE
Do not provide an input for current year of earnings

### DIFF
--- a/src/components/file-upload.jsx
+++ b/src/components/file-upload.jsx
@@ -232,7 +232,7 @@ export default class FileUpload extends React.Component {
 
     var tempTable = {};
     const yearCountForLoopLength = (!supportDatesAfterToday &&
-       retiredate<= new Date().getFullYear()) ? retiredate : new Date().getFullYear() 
+       retiredate<= new Date().getFullYear()) ? retiredate : new Date().getFullYear() - 1
     if (birthdate !== undefined && retiredate !== undefined) {
       for (var i = birthdate; i <= yearCountForLoopLength; i++) {
         if (Object.keys(earningsValue).includes(String(i))) {


### PR DESCRIPTION
Unless the `supportDatesAfterToday` is set true, do not show e.g. 2020 in the earning input because the tables may not be updated for that year yet.

This was causing a `TypeError "n.find(...) is undefined` error for manual entry once we got into 2020.