### PR TITLE
User State Migration: Prescreen 1C

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+  "plugins": ["@babel/plugin-proposal-nullish-coalescing-operator"],
+  "presets": [
+    [
+      "babel-preset-gatsby"
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "windfall-awareness-notebook-prototype": "https://api.observablehq.com/@thadk/windfall-awareness-notebook-prototype.tgz?v=1"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
     "@types/rc-slider": "^8.6.5",
     "@types/react": "^16.8.8",
     "@types/react-dom": "^16.8.3",

--- a/src/library/user-state-actions-context.tsx
+++ b/src/library/user-state-actions-context.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import {EarningsEnum} from './user-state-context'
+import {EarningsEnum, PensionEnum} from './user-state-context'
 
 export interface UserStateActions {
   setBirthDate: (date: Date) => void
@@ -9,6 +9,10 @@ export interface UserStateActions {
   setHaveEarnings: (hasEarnings: boolean) => void
   setEarningsFormat: (format: EarningsEnum) => void
   setHaveSSAAccount: (hasSSAAccount: boolean) => void
+  setIsEmploymentCovered: (isCovered: boolean) => void
+  setPensionOrRetirementAccount: (value: PensionEnum) => void
+  setPensionAmount: (amount: number) => void
+  setPensionDateAwarded: (date: Date) => void
 }
 
 const UserStateActionsContext = React.createContext<UserStateActions | null>(null)

--- a/src/library/user-state-context.tsx
+++ b/src/library/user-state-context.tsx
@@ -11,6 +11,12 @@ export interface EarningsData {
   [year: string]: number
 }
 
+export enum PensionEnum {
+  PENSION = "MONTHLYPENSION",
+  LUMPSUM = "LUMPSUMRETIREMENTACCOUNT",
+  NONEOFABOVE = "NONEOFABOVE"
+}
+
 export interface UserState {
   birthDate: Date | null
   retireDate: Date | null
@@ -21,6 +27,10 @@ export interface UserState {
   haveEarnings: boolean | null
   earningsFormat: EarningsEnum | null
   haveSSAAccount: boolean | null
+  isEmploymentCovered: boolean | null
+  pensionOrRetirementAccount: PensionEnum | null
+  pensionAmount: number | null
+  pensionDateAwarded: Date | null
 }
 
 const UserStateContext = React.createContext<UserState | null>(null)

--- a/src/library/user-state-manager.tsx
+++ b/src/library/user-state-manager.tsx
@@ -2,7 +2,7 @@ import React, {useMemo} from 'react'
 import createPersistedState from 'use-persisted-state';
 import dayjs from 'dayjs'
 
-import {UserStateContextProvider, UserState, EarningsEnum, EarningsData } from './user-state-context'
+import {UserStateContextProvider, UserState, EarningsEnum, EarningsData, PensionEnum } from './user-state-context'
 import {UserStateActions, UserStateActionsContextProvider} from './user-state-actions-context'
 
 // Must use sessionStorage (not localStorage) or else it conflicts with other uses of sessionStorage within app
@@ -11,6 +11,11 @@ const useHaveEarningsState = createPersistedState('haveEarnings', global.session
 const useEarningsFormatState = createPersistedState('earningsFormat', global.sessionStorage);
 const useHaveSSAAccountState = createPersistedState('haveSSAAccount', global.sessionStorage);
 const useEarningsState = createPersistedState('earnings', global.sessionStorage);
+const useIsEmploymentCoveredState = createPersistedState('coveredEmployment', global.sessionStorage);
+const usePensionOrRetirementAccountState = createPersistedState('pensionOrRetirementAccount', global.sessionStorage)
+const usePensionAmountState = createPersistedState('pensionAmount', global.sessionStorage)
+const usePensionDateAwarded = createPersistedState('dateAwarded', global.sessionStorage)
+
 
 // TODO The following should eventually be derived from the state values persisted to storage
 const useRetireDateState = createPersistedState('RetireDate', global.sessionStorage);
@@ -39,6 +44,10 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
   const [haveEarnings, setHaveEarnings] = useHaveEarningsState<boolean | null>(null)
   const [earningsFormat, setEarningsFormat] = useEarningsFormatState<EarningsEnum | null>(null)
   const [haveSSAAccount, setHaveSSAAccount] = useHaveSSAAccountState<boolean | null>(null)
+  const [isEmploymentCovered, setIsEmploymentCovered] = useIsEmploymentCoveredState<boolean | null>(null)
+  const [pensionOrRetirementAccount, setPensionOrRetirementAccount] = usePensionOrRetirementAccountState<PensionEnum | null>(null)
+  const [pensionAmount, setPensionAmount] = usePensionAmountState<number | null>(null)
+  const [pensionDateAwarded, setPensionDateAwarded] = usePensionDateAwarded<Date | null>(null)
 
   const userState: UserState = useMemo(() => ({
     birthDate: birthDate ? new Date(birthDate) : null,
@@ -50,7 +59,11 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
     haveEarnings,
     earningsFormat,
     haveSSAAccount,
-  }), [birthDate, earningsFormat, haveEarnings, haveSSAAccount, retireDate, year62])
+    isEmploymentCovered,
+    pensionOrRetirementAccount,
+    pensionAmount,
+    pensionDateAwarded,
+  }), [birthDate, earningsFormat, haveEarnings, haveSSAAccount, isEmploymentCovered, pensionAmount, pensionDateAwarded, pensionOrRetirementAccount, retireDate, year62])
 
   const actions: UserStateActions = useMemo(() => ({
     setBirthDate: date => setBirthDate(startOfDay(date)),
@@ -59,7 +72,11 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
     setHaveEarnings,
     setEarningsFormat,
     setHaveSSAAccount,
-  }), [setBirthDate, setEarningsFormat, setHaveEarnings, setHaveSSAAccount, setRetireDate, setYear62])
+    setIsEmploymentCovered,
+    setPensionOrRetirementAccount,
+    setPensionAmount,
+    setPensionDateAwarded,
+  }), [setBirthDate, setEarningsFormat, setHaveEarnings, setHaveSSAAccount, setIsEmploymentCovered, setPensionAmount, setPensionDateAwarded, setPensionOrRetirementAccount, setRetireDate, setYear62])
 
   return (
     <UserStateContextProvider value={userState}>

--- a/src/pages/prescreen-1c.tsx
+++ b/src/pages/prescreen-1c.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "@emotion/styled";
 import DatePicker from "react-datepicker";
-import { Link } from "gatsby";
 import { colors } from "../constants";
 import dayjs from "dayjs";
 import {
@@ -13,10 +12,10 @@ import {
   LabelText,
   H2,
   Glossary,
-  AnswerInput,
   AnswerInputDiscouragePlaceholder
 } from "../components";
-import { SessionStore } from "../library/session-store";
+import {PensionEnum, useUserState, UserState} from '../library/user-state-context'
+import {useUserStateActions, UserStateActions} from '../library/user-state-actions-context'
 
 const StyledDatePicker = styled(DatePicker)`
   border: 2px solid ${colors.purple};
@@ -46,103 +45,53 @@ width: 70%;
 margin-bottom: 75px;
 `;
 
-function booleanFromString(s: string | null) {
-  if (s) {
-    return s === "true";
-  } else {
-    return null;
-  }
+interface Prescreen1cProps {
+  userState: UserState
+  userStateActions: UserStateActions
 }
 
-enum PensionEnum {
-	PENSION = "MONTHLYPENSION",
-	LUMPSUM = "LUMPSUMRETIREMENTACCOUNT",
-	NONEOFABOVE = "NONEOFABOVE",
-}
-
-export default class Prescreen1c extends React.Component {
-  constructor(props, context) {
-    super(props, context)
-    this.handleSelection = this.handleSelection.bind(this);
-    this.handleDateChange = this.handleDateChange.bind(this);
-    this.state = {
-      isLoaded: false,
-      dateAwarded: null,
-      coveredEmployment: null,
-      pensionOrRetirementAccount: null,
-      pensionType: null,
-      pensionAmount: null
-    }
-  }
-
-  componentDidMount() {
-    if (SessionStore.get("dateAwarded") && (this.state.dateAwarded === null)){
-      var dateAwarded = new Date(JSON.parse(SessionStore.get("dateAwarded")))
-      this.setState({
-        dateAwarded: dateAwarded
-      })
-    }
-
-    if (!this.state.isLoaded) {
-      this.setState({
-        isLoaded: true,
-        coveredEmployment:
-          booleanFromString(SessionStore.get("coveredEmployment")),
-        pensionOrRetirementAccount:
-          SessionStore.get("pensionOrRetirementAccount"),
-        pensionType: SessionStore.get("pensionType")
-          ? SessionStore.get("pensionType")
-          : null,
-        pensionAmount: SessionStore.get("pensionAmount")
-          ? SessionStore.get("pensionAmount")
-          : undefined
-      });
-    }
-  }
-  
-  handleDateChange(name, value){
+class Prescreen1c extends React.Component<Prescreen1cProps> {
+  handleDateAwardedChange = (value: Date) => {
+    const {userStateActions: {setPensionDateAwarded}} = this.props
     if (name === "dateAwardedPicked") {
-      SessionStore.push("dateAwarded", JSON.stringify(value))
-      var state = {dateAwarded: value}
-      this.setState(state)
+      setPensionDateAwarded(value)
     }
   }
-  
-  handleSelection(e) {
-    let selectValueString = e.target.value;
-    let selectValue;
 
+  handleSelection = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const {
+      userStateActions: {
+        setIsEmploymentCovered,
+        setPensionOrRetirementAccount,
+        setPensionAmount,
+      }
+    } = this.props
+    const selectValueString = e.target.value;
     switch (e.target.name) {
       case "coveredEmployment":
-        selectValue = booleanFromString(selectValueString);
-        SessionStore.push("coveredEmployment", selectValue);
-        this.setState({
-          coveredEmployment: selectValue
-        });
+        const isCovered = selectValueString === 'true'
+        setIsEmploymentCovered(isCovered)
         break;
       case "pensionOrRetirementAccount":
-        SessionStore.push("pensionOrRetirementAccount", selectValueString);
-        this.setState({
-          pensionOrRetirementAccount: selectValueString
-        });
-        break;
-      case "monthlyPension":
-      case "lumpSum":
-        SessionStore.push("pensionType", e.target.name);
-        this.setState({
-          pensionType: e.target.name
-        });
+        setPensionOrRetirementAccount(selectValueString as PensionEnum)
         break;
       case "pensionAmount":
-        SessionStore.push("pensionAmount", e.target.value);
-        this.setState({
-          pensionAmount: e.target.value
-        });
+        const pensionAmount = parseFloat(e.target.value)
+        if (!isNaN(pensionAmount) && pensionAmount > 0) setPensionAmount(pensionAmount)
+        else setPensionAmount(0)
         break;
     }
   }
 
   render() {
+    const {
+      userState: {
+        isEmploymentCovered,
+        pensionDateAwarded,
+        pensionAmount,
+        pensionOrRetirementAccount
+      }
+    } = this.props
     return (
       <React.Fragment>
         <SEO
@@ -162,9 +111,7 @@ export default class Prescreen1c extends React.Component {
                   type="radio"
                   name="coveredEmployment"
                   value="true"
-                  {...(this.state.coveredEmployment === true
-                    ? { checked: true }
-                    : { checked: false })}
+                  checked={isEmploymentCovered === true}
                   onChange={this.handleSelection}
                 />
                 <LabelText>Yes</LabelText>
@@ -174,9 +121,7 @@ export default class Prescreen1c extends React.Component {
                   type="radio"
                   name="coveredEmployment"
                   value="false"
-                  {...(this.state.coveredEmployment === false
-                    ? { checked: true }
-                    : { checked: false })}
+                  checked={isEmploymentCovered === false}
                   onChange={this.handleSelection}
                 />
                 <LabelText>No</LabelText>
@@ -194,7 +139,7 @@ export default class Prescreen1c extends React.Component {
           will not show up on a Social Security record.
         </Glossary>
             </CardGlossaryContainer>
-            {this.state.coveredEmployment && (
+            {isEmploymentCovered && (
             <CardGlossaryContainer>
               <Card>
                 <QuestionText>
@@ -203,15 +148,15 @@ the work you did that does not show up on your
 Social Security record?
                 </QuestionText>
                 <AnswerBox>
-                  <RadioButton type="radio" name="pensionOrRetirementAccount" value={PensionEnum.PENSION} onChange={this.handleSelection} checked={this.state.pensionOrRetirementAccount === PensionEnum.PENSION} />
+                  <RadioButton type="radio" name="pensionOrRetirementAccount" value={PensionEnum.PENSION} onChange={this.handleSelection} checked={pensionOrRetirementAccount === PensionEnum.PENSION} />
                   <LabelText>Monthly pension</LabelText>
                 </AnswerBox>
                 <AnswerBox>
-                  <RadioButton type="radio" name="pensionOrRetirementAccount" value={PensionEnum.LUMPSUM} onChange={this.handleSelection} checked={this.state.pensionOrRetirementAccount === PensionEnum.LUMPSUM} />
+                  <RadioButton type="radio" name="pensionOrRetirementAccount" value={PensionEnum.LUMPSUM} onChange={this.handleSelection} checked={pensionOrRetirementAccount === PensionEnum.LUMPSUM} />
                   <LabelText>Retirement account</LabelText>
                 </AnswerBox>
                 <AnswerBox>
-                  <RadioButton type="radio" name="pensionOrRetirementAccount" value={PensionEnum.NONEOFABOVE} onChange={this.handleSelection} checked={this.state.pensionOrRetirementAccount === PensionEnum.NONEOFABOVE} />
+                  <RadioButton type="radio" name="pensionOrRetirementAccount" value={PensionEnum.NONEOFABOVE} onChange={this.handleSelection} checked={pensionOrRetirementAccount === PensionEnum.NONEOFABOVE} />
                   <LabelText>None of the above</LabelText>
                 </AnswerBox>
               </Card>
@@ -224,7 +169,7 @@ Social Security record?
               </Glossary>
             </CardGlossaryContainer>
             )}
-            {this.state.coveredEmployment &&  this.state.pensionOrRetirementAccount && this.state.pensionOrRetirementAccount !== PensionEnum.NONEOFABOVE && (
+            {isEmploymentCovered &&  pensionOrRetirementAccount && pensionOrRetirementAccount !== PensionEnum.NONEOFABOVE && (
               <>
               <Card>
                 <label>
@@ -233,13 +178,13 @@ Social Security record?
                   </QuestionText>
                   <AnswerInputDiscouragePlaceholder
                     name="pensionAmount"
-                    defaultValue={this.state.pensionAmount}
+                    defaultValue={pensionAmount || 0}
                     placeholder={'0'}  
                     onChange={this.handleSelection}
                   ></AnswerInputDiscouragePlaceholder>
                 </label>
               </Card>
-              {this.state.pensionOrRetirementAccount === PensionEnum.LUMPSUM && (
+              {pensionOrRetirementAccount === PensionEnum.LUMPSUM && (
                 <Card>
                     <QuestionText>
                       Please enter the date you become eligible to start withdrawing from the your retirement account without penalty.
@@ -247,10 +192,10 @@ Social Security record?
                     <StyledDatePicker
                     id="dateAwardedPicked"
                     placeholderText="Click to select a date"
-                    selected={this.state.dateAwarded}
+                    selected={pensionDateAwarded}
                     showYearDropdown
-                    openToDate={this.state.dateAwarded || dayjs().subtract(3, 'years').toDate()}
-                    onChange={(value) => this.handleDateChange("dateAwardedPicked", value)}
+                    openToDate={pensionDateAwarded || dayjs().subtract(3, 'year').toDate()}
+                    onChange={this.handleDateAwardedChange}
                     />
                 </Card>
               )}
@@ -260,4 +205,10 @@ Social Security record?
       </React.Fragment>
     );
   }
+}
+
+export default function Prescreen1cWrapper(): JSX.Element {
+  const userState = useUserState()
+  const userStateActions = useUserStateActions()
+  return <Prescreen1c userState={userState} userStateActions={userStateActions} />
 }

--- a/src/pages/prescreen-1c.tsx
+++ b/src/pages/prescreen-1c.tsx
@@ -178,7 +178,7 @@ Social Security record?
                   </QuestionText>
                   <AnswerInputDiscouragePlaceholder
                     name="pensionAmount"
-                    defaultValue={pensionAmount || 0}
+                    defaultValue={pensionAmount ?? undefined}
                     placeholder={'0'}  
                     onChange={this.handleSelection}
                   ></AnswerInputDiscouragePlaceholder>


### PR DESCRIPTION
This time, we also dropped the `pensionType` state field since it seemed to not be used or referenced anywhere (probably dead code.)