### PR TITLE
Migrate FileUpload components

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@observablehq/runtime": "4.2.1",
     "@reach/router": "^1.2.1",
     "@rebass/grid": "^6.0.0",
+    "@types/pdfjs-dist": "^2.1.3",
     "@types/react-datepicker": "^2.10.0",
     "@types/react-helmet": "^5.0.8",
     "@types/use-persisted-state": "^0.3.0",

--- a/src/library/user-state-actions-context.tsx
+++ b/src/library/user-state-actions-context.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react'
 
-import {EarningsEnum} from './user-state-context'
+import {EarningsEnum, EarningsRecord} from './user-state-context'
 
 export interface UserStateActions {
   setBirthDate: (date: Date) => void
   setRetireDate: (date: Date) => void
   setYear62: (year: number) => void
   setHaveEarnings: (hasEarnings: boolean) => void
+  setEarnings: (earnings: EarningsRecord) => void
   setEarningsFormat: (format: EarningsEnum) => void
   setHaveSSAAccount: (hasSSAAccount: boolean) => void
 }

--- a/src/library/user-state-context.tsx
+++ b/src/library/user-state-context.tsx
@@ -7,7 +7,7 @@ export enum EarningsEnum {
   PAPER = "PAPER"
 }
 
-export interface EarningsData {
+export interface EarningsRecord {
   [year: string]: number
 }
 
@@ -20,6 +20,7 @@ export interface UserState {
   year62: number | null
   haveEarnings: boolean | null
   earningsFormat: EarningsEnum | null
+  earnings: EarningsRecord | null
   haveSSAAccount: boolean | null
 }
 

--- a/src/library/user-state-manager.tsx
+++ b/src/library/user-state-manager.tsx
@@ -2,7 +2,7 @@ import React, {useMemo} from 'react'
 import createPersistedState from 'use-persisted-state';
 import dayjs from 'dayjs'
 
-import {UserStateContextProvider, UserState, EarningsEnum, EarningsData } from './user-state-context'
+import {UserStateContextProvider, UserState, EarningsEnum, EarningsRecord } from './user-state-context'
 import {UserStateActions, UserStateActionsContextProvider} from './user-state-actions-context'
 
 // Must use sessionStorage (not localStorage) or else it conflicts with other uses of sessionStorage within app
@@ -37,6 +37,7 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
   const [retireDate, setRetireDate] = useRetireDateState<Date | null>(null)
   const [year62, setYear62] = useYear62State<number | null>(null)
   const [haveEarnings, setHaveEarnings] = useHaveEarningsState<boolean | null>(null)
+  const [earnings, setEarnings] = useEarningsState<EarningsRecord | null>(null)
   const [earningsFormat, setEarningsFormat] = useEarningsFormatState<EarningsEnum | null>(null)
   const [haveSSAAccount, setHaveSSAAccount] = useHaveSSAAccountState<boolean | null>(null)
 
@@ -48,18 +49,20 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
     fullRetirementAgeMonthsOnly: (birthDate && retireDate) ? dayjs(retireDate).diff(birthDate, 'month', false) % 12: null,
     year62,
     haveEarnings,
+    earnings,
     earningsFormat,
     haveSSAAccount,
-  }), [birthDate, earningsFormat, haveEarnings, haveSSAAccount, retireDate, year62])
+  }), [birthDate, earnings, earningsFormat, haveEarnings, haveSSAAccount, retireDate, year62])
 
   const actions: UserStateActions = useMemo(() => ({
     setBirthDate: date => setBirthDate(startOfDay(date)),
     setRetireDate: date => setRetireDate(startOfDay(date)),
     setYear62,
     setHaveEarnings,
+    setEarnings,
     setEarningsFormat,
     setHaveSSAAccount,
-  }), [setBirthDate, setEarningsFormat, setHaveEarnings, setHaveSSAAccount, setRetireDate, setYear62])
+  }), [setBirthDate, setEarnings, setEarningsFormat, setHaveEarnings, setHaveSSAAccount, setRetireDate, setYear62])
 
   return (
     <UserStateContextProvider value={userState}>


### PR DESCRIPTION
Migrates the file from `*.jsx` to `*.tsx` and persists the earnings record to session storage!

To Do:
- [ ] Find a way to remove the `manualTable` state and use `earnings` across the board
- [ ] Reset earnings data if the user switches format types
- [ ] Switch from `handle*` prop names to `on*` convention