### PR TITLE
Remove RawData key from UserProfile object

### DIFF
--- a/src/library/observable-functions.js
+++ b/src/library/observable-functions.js
@@ -539,22 +539,24 @@ function lumpSumToMonthly(lumpSum, dateAwarded, workerAge, dob){
 ///////////////////////////////
 
 async function finalCalculation(birthDatePicked, retireDatePicked, yearof62yo, yearsSubstantialEarningsPicked, pensionNonCoveredMonthly, AIMEPicked) {
-
-  var userCalc = {}
   const userFullRetireDate = getFullRetirementDate(new Date(birthDatePicked))
-	const standardPIA = await getPIA(AIMEPicked, birthDatePicked, null, false)
-	const wepPIA = await getPIA(AIMEPicked, birthDatePicked, yearsSubstantialEarningsPicked, true)
-	const wepDiff = (await getPIA(AIMEPicked, birthDatePicked, null, false) - await getPIA(AIMEPicked, birthDatePicked, yearsSubstantialEarningsPicked, true))
-	const wepMPB = await getWepMPB(AIMEPicked, birthDatePicked, retireDatePicked, yearof62yo, yearsSubstantialEarningsPicked, pensionNonCoveredMonthly)
+  const standardPIA = await getPIA(AIMEPicked, birthDatePicked, null, false)
+  const wepPIA = await getPIA(AIMEPicked, birthDatePicked, yearsSubstantialEarningsPicked, true)
+  const wepDiff = (await getPIA(AIMEPicked, birthDatePicked, null, false) - await getPIA(AIMEPicked, birthDatePicked, yearsSubstantialEarningsPicked, true))
+  const wepMPB = await getWepMPB(AIMEPicked, birthDatePicked, retireDatePicked, yearof62yo, yearsSubstantialEarningsPicked, pensionNonCoveredMonthly)
 
-  userCalc["Standard PIA"] = standardPIA.toFixed(2)
-  userCalc["WEP PIA"] = wepPIA.toFixed(2)
-  userCalc["WEP Diff"] = wepDiff.toFixed(2)
-  userCalc["MPB"] = wepMPB.toFixed(2)
+  const userProfile = {
+    "Standard PIA": standardPIA.toFixed(2),
+    "WEP PIA": wepPIA.toFixed(2),
+    "WEP Diff": wepDiff.toFixed(2),
+    MPB: wepMPB.toFixed(2),
+    yearsSubstantialEarnings: yearsSubstantialEarningsPicked,
+    pensionNonCoveredMonthly: pensionNonCoveredMonthly,
+    aime: AIMEPicked,
+    fullRetireDate: userFullRetireDate,
+  }
 
-  userCalc["RawData"] = {birthDatePicked, retireDatePicked, yearof62yo, yearsSubstantialEarningsPicked, pensionNonCoveredMonthly, AIMEPicked, userFullRetireDate}
-
-  return userCalc
+  return userProfile
 }
 
 

--- a/src/library/user-state-context.tsx
+++ b/src/library/user-state-context.tsx
@@ -22,8 +22,10 @@ export interface UserProfile {
   'WEP PIA': string
   'WEP Diff': string
   MPB: string
-  // TODO Type this more thoroughly
-  RawData: any
+  yearsSubstantialEarnings: number
+  pensionNonCoveredMonthly: number | null | undefined
+  aime: number
+  fullRetireDate: string
 }
 
 export interface UserState {

--- a/src/library/user-state-context.tsx
+++ b/src/library/user-state-context.tsx
@@ -17,6 +17,7 @@ export enum PensionEnum {
   NONEOFABOVE = "NONEOFABOVE"
 }
 
+// Calculated results for the user
 export interface UserProfile {
   'Standard PIA': string
   'WEP PIA': string

--- a/src/pages/print.tsx
+++ b/src/pages/print.tsx
@@ -205,9 +205,10 @@ class Print extends React.Component<PrintProps> {
 
     if (!userProfile) return null
 
-    const userAIME = userProfile['RawData']['AIMEPicked']
-    const userYSE = userProfile['RawData']['yearsSubstantialEarningsPicked']
-    const userPension = userProfile["RawData"]["pensionNonCoveredMonthly"]
+    const userAIME = userProfile.aime
+    const userFRD = userProfile.fullRetireDate
+    const userYSE = userProfile.yearsSubstantialEarnings
+    const userPension = userProfile.pensionNonCoveredMonthly
     const userStandardPIA = userProfile["Standard PIA"]
     const userMPB = userProfile["MPB"]
     return(
@@ -241,7 +242,7 @@ class Print extends React.Component<PrintProps> {
             <Row>Monthly non-covered pension amount:<BoxDisplay><strong>${userPension}</strong></BoxDisplay></Row>
 
             {retireDate && (
-              <Row>Date of Full Retirement Age:<BoxDisplay><strong>{retireDate.toLocaleDateString('en-US')}</strong></BoxDisplay></Row>
+              <Row>Date of Full Retirement Age:<BoxDisplay><strong>{userFRD}</strong></BoxDisplay></Row>
             )}
           </ResultsCard>
           {earnings && (

--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -63,7 +63,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
       })
   }
 
-  computeUserCalc = async (userDOR: Date) => {
+  computeUserCalc = async (userDOR: Date): Promise<UserProfile> => {
     const {
       userState: {
         birthDate,


### PR DESCRIPTION
The `RawData` key on the profile object was typed as `any` and made it hard to use. Since many of the fields were duplicates of fields on the user context, I was able to remove most of them and consolidate the rest on the profile object.

In the process I found a mistake I introduced in the print PR related to the full retirement date. Fixed that here!