### PR TITLE
Fix page crash bug related to datepicker

### DIFF
--- a/src/library/user-state-actions-context.tsx
+++ b/src/library/user-state-actions-context.tsx
@@ -3,8 +3,8 @@ import * as React from 'react'
 import {EarningsEnum, EarningsRecord, PensionEnum, UserProfile} from './user-state-context'
 
 export interface UserStateActions {
-  setBirthDate: (date: Date) => void
-  setRetireDate: (date: Date) => void
+  setBirthDate: (date: Date|null) => void
+  setRetireDate: (date: Date|null) => void
   setYear62: (year: number) => void
   setHaveEarnings: (hasEarnings: boolean) => void
   setEarnings: (earnings: EarningsRecord) => void

--- a/src/library/user-state-actions-context.tsx
+++ b/src/library/user-state-actions-context.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react'
 
-import {EarningsEnum, EarningsRecord, PensionEnum, UserProfile} from './user-state-context'
+import { EarningsEnum, EarningsRecord, PensionEnum, UserProfile } from './user-state-context'
 
 export interface UserStateActions {
-  setBirthDate: (date: Date|null) => void
-  setRetireDate: (date: Date|null) => void
+  setBirthDate: (date: Date | null) => void
+  setRetireDate: (date: Date | null) => void
   setYear62: (year: number) => void
   setHaveEarnings: (hasEarnings: boolean) => void
   setEarnings: (earnings: EarningsRecord) => void

--- a/src/library/user-state-manager.tsx
+++ b/src/library/user-state-manager.tsx
@@ -77,20 +77,36 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
     userProfile,
   }), [birthDate, earnings, earningsFormat, haveEarnings, haveSSAAccount, isEmploymentCovered, pensionAmount, pensionDateAwarded, pensionOrRetirementAccount, retireDate, userProfile, year62])
 
-  const actions: UserStateActions = useMemo(() => ({
-    setBirthDate: date => setBirthDate(startOfDay(date)),
-    setRetireDate: date => setRetireDate(startOfDay(date)),
-    setYear62,
-    setHaveEarnings,
-    setEarnings,
-    setEarningsFormat,
-    setHaveSSAAccount,
-    setIsEmploymentCovered,
-    setPensionOrRetirementAccount,
-    setPensionAmount,
-    setPensionDateAwarded,
-    setUserProfile,
-  }), [setBirthDate, setEarnings, setEarningsFormat, setHaveEarnings, setHaveSSAAccount, setIsEmploymentCovered, setPensionAmount, setPensionDateAwarded, setPensionOrRetirementAccount, setRetireDate, setUserProfile, setYear62])
+  const actions: UserStateActions = useMemo(
+    () => ({
+      setBirthDate: (date) => setBirthDate(date ? startOfDay(date) : null),
+      setRetireDate: (date) => setRetireDate(date ? startOfDay(date) : null),
+      setYear62,
+      setHaveEarnings,
+      setEarnings,
+      setEarningsFormat,
+      setHaveSSAAccount,
+      setIsEmploymentCovered,
+      setPensionOrRetirementAccount,
+      setPensionAmount,
+      setPensionDateAwarded,
+      setUserProfile,
+    }),
+    [
+      setBirthDate,
+      setEarnings,
+      setEarningsFormat,
+      setHaveEarnings,
+      setHaveSSAAccount,
+      setIsEmploymentCovered,
+      setPensionAmount,
+      setPensionDateAwarded,
+      setPensionOrRetirementAccount,
+      setRetireDate,
+      setUserProfile,
+      setYear62,
+    ]
+  );
 
   return (
     <UserStateContextProvider value={userState}>

--- a/src/library/user-state-manager.tsx
+++ b/src/library/user-state-manager.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react'
+import React, { useMemo } from 'react'
 import createPersistedState from 'use-persisted-state';
 import dayjs from 'dayjs'
 
@@ -10,7 +10,7 @@ import {
   PensionEnum,
   UserProfile
 } from './user-state-context'
-import {UserStateActions, UserStateActionsContextProvider} from './user-state-actions-context'
+import { UserStateActions, UserStateActionsContextProvider } from './user-state-actions-context'
 
 // Must use sessionStorage (not localStorage) or else it conflicts with other uses of sessionStorage within app
 const useBirthDateState = createPersistedState('BirthDate', global.sessionStorage);
@@ -45,7 +45,7 @@ interface UserStateManagerProps {
  * the user state and a set of actions to mutate that state, while persisting it to session storage.
  */
 export default function UserStateManager(props: UserStateManagerProps): JSX.Element {
-  const {children} = props
+  const { children } = props
   const [birthDate, setBirthDate] = useBirthDateState<Date | null>(null)
   const [retireDate, setRetireDate] = useRetireDateState<Date | null>(null)
   const [year62, setYear62] = useYear62State<number | null>(null)
@@ -62,9 +62,9 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
   const userState: UserState = useMemo(() => ({
     birthDate: birthDate ? new Date(birthDate) : null,
     retireDate: retireDate ? new Date(retireDate) : null,
-    fullRetirementAge: (birthDate && retireDate) ? dayjs(retireDate).diff(birthDate, 'year', true): null,
-    fullRetirementAgeYearsOnly: (birthDate && retireDate) ? dayjs(retireDate).diff(birthDate, 'year', false): null,
-    fullRetirementAgeMonthsOnly: (birthDate && retireDate) ? dayjs(retireDate).diff(birthDate, 'month', false) % 12: null,
+    fullRetirementAge: (birthDate && retireDate) ? dayjs(retireDate).diff(birthDate, 'year', true) : null,
+    fullRetirementAgeYearsOnly: (birthDate && retireDate) ? dayjs(retireDate).diff(birthDate, 'year', false) : null,
+    fullRetirementAgeMonthsOnly: (birthDate && retireDate) ? dayjs(retireDate).diff(birthDate, 'month', false) % 12 : null,
     year62,
     haveEarnings,
     earnings,

--- a/src/pages/prescreen-1a.tsx
+++ b/src/pages/prescreen-1a.tsx
@@ -50,7 +50,7 @@ class Prescreen1a extends React.Component<Prescreen1aProps, Prescreen1aState> {
 
   async handleDateChange(name, value) {
     const {userStateActions} = this.props
-    if (name === "birthDatePicked") {
+    if (value && name === "birthDatePicked") {
       userStateActions.setBirthDate(value)
 
       var year62 = new Date(value).getFullYear() + 62;

--- a/src/pages/prescreen-1a.tsx
+++ b/src/pages/prescreen-1a.tsx
@@ -61,7 +61,7 @@ class Prescreen1a extends React.Component<Prescreen1aProps, Prescreen1aState> {
       this.setRetireDate(value, fullRetirementAge)
     } else if (value === null) {
       userStateActions.setBirthDate(null);
-      this.setRetireDate(null, null);
+      userStateActions.setRetireDate(null);
     }
   }
 
@@ -69,13 +69,10 @@ class Prescreen1a extends React.Component<Prescreen1aProps, Prescreen1aState> {
     const { userStateActions } = this.props
     /* dayjs cannot .add() fractional years that we put into the tables
        but only months, so let us use rounded months. */
-    if (dateOfBirth) {
       const retireAgeInRoundedMonths = Math.round(await retireAge * 12)
       var retireDate = dayjs(dateOfBirth).add(retireAgeInRoundedMonths, 'month').toDate()
       userStateActions.setRetireDate(retireDate)
-    } else {
-      userStateActions.setRetireDate(null)
-    }
+    
   }
 
   //TODO: remove the decimal years and display YY years and MM months.

--- a/src/pages/prescreen-1a.tsx
+++ b/src/pages/prescreen-1a.tsx
@@ -6,8 +6,8 @@ import * as ObsFuncs from "../library/observable-functions";
 import { colors } from "../constants";
 import dayjs from "dayjs";
 
-import {UserState, useUserState} from '../library/user-state-context'
-import {UserStateActions, useUserStateActions} from '../library/user-state-actions-context'
+import { UserState, useUserState } from '../library/user-state-context'
+import { UserStateActions, useUserStateActions } from '../library/user-state-actions-context'
 
 import {
   TextBlock,
@@ -40,7 +40,7 @@ interface Prescreen1aProps {
 }
 
 class Prescreen1a extends React.Component<Prescreen1aProps, Prescreen1aState> {
-  constructor(props, context){
+  constructor(props, context) {
     super(props, context)
     this.handleDateChange = this.handleDateChange.bind(this);
   }
@@ -49,84 +49,113 @@ class Prescreen1a extends React.Component<Prescreen1aProps, Prescreen1aState> {
   }
 
   async handleDateChange(name, value) {
-    const {userStateActions} = this.props
+    const { userStateActions } = this.props;
+
     if (value && name === "birthDatePicked") {
       userStateActions.setBirthDate(value)
-
       var year62 = new Date(value).getFullYear() + 62;
       userStateActions.setYear62(year62)
       var fullRetirementAge = 0;
 
       fullRetirementAge = await ObsFuncs.getFullRetirementDateSimple(value)
       this.setRetireDate(value, fullRetirementAge)
+    } else if (value === null) {
+      userStateActions.setBirthDate(null);
+      this.setRetireDate(null, null);
     }
   }
 
   async setRetireDate(dateOfBirth, retireAge) {
-    const {userStateActions} = this.props
-
+    const { userStateActions } = this.props
     /* dayjs cannot .add() fractional years that we put into the tables
        but only months, so let us use rounded months. */
-    const retireAgeInRoundedMonths = Math.round(await retireAge * 12)
-    var retireDate = dayjs(dateOfBirth).add(retireAgeInRoundedMonths, 'month').toDate()
-
-    userStateActions.setRetireDate(retireDate)
+    if (dateOfBirth) {
+      const retireAgeInRoundedMonths = Math.round(await retireAge * 12)
+      var retireDate = dayjs(dateOfBirth).add(retireAgeInRoundedMonths, 'month').toDate()
+      userStateActions.setRetireDate(retireDate)
+    } else {
+      userStateActions.setRetireDate(null)
+    }
   }
 
   //TODO: remove the decimal years and display YY years and MM months.
   //this.friendlyRetirementAge(this.state.birthDate, this.state.retireDate, this.state.retireAge)
-// friendlyRetirementAge(dobDayJS,retireDateString, retireAge) {
-//     if (dobDayJS !== null && retireDateString && retireAge ) {
-//       return dayjs(dobDayJS).diff(dayjs(retireDateString),'months') % Number(retireAge)
-//     } else {
-//       return
-//     }
-//   }
+  // friendlyRetirementAge(dobDayJS,retireDateString, retireAge) {
+  //     if (dobDayJS !== null && retireDateString && retireAge ) {
+  //       return dayjs(dobDayJS).diff(dayjs(retireDateString),'months') % Number(retireAge)
+  //     } else {
+  //       return
+  //     }
+  //   }
 
-    render() {
-        const {userState} = this.props
-        const {birthDate, retireDate, fullRetirementAgeYearsOnly, fullRetirementAgeMonthsOnly} = userState
-        const retireDateYear = retireDate ? retireDate.getFullYear() : null
-        return (
-            <div>
-                <SEO title="Pre-Screen 1a" keywords={[`gatsby`, `application`, `react`]} />
-                <H2>Step 1: Background Information</H2>
-                <TextBlock>
-                    To calculate your Social Security benefit, please input the following dates.
-                </TextBlock>
-                  <Card>
-                    <H4>Birthdate</H4>
-                    <StyledDatePicker
-                    id="birthDatePicked"
-                    placeholderText="Click to select a date"
-                    selected={birthDate}
-                    showYearDropdown
-                    openToDate={birthDate || dayjs().subtract(64, 'year').toDate()}
-                    onChange={(value) => this.handleDateChange("birthDatePicked", value)}
-                    />
-                  </Card>
-                  { retireDateYear && 
-                    <Card>
-                    <H4>Retirement Age</H4>
-                    <p>Your Full Retirement Age (FRA) to collect Social Security
-                       Benefits is {fullRetirementAgeYearsOnly} years 
-                       {fullRetirementAgeMonthsOnly ? " and " + 
-                       fullRetirementAgeMonthsOnly+ " months ": ""} old<a href="https://www.ssa.gov/OACT/ProgData/ar_drc.html"><sup>1</sup></a>, 
-                       which is in year {retireDateYear}.
-                      { /* TODO remove this and replace with a function that
+  render() {
+    const { userState } = this.props
+    const { birthDate, retireDate, fullRetirementAgeYearsOnly, fullRetirementAgeMonthsOnly } = userState
+    const retireDateYear = retireDate ? retireDate.getFullYear() : null
+    return (
+      <div>
+        <SEO
+          title="Pre-Screen 1a"
+          keywords={[`gatsby`, `application`, `react`]}
+        />
+        <H2>Step 1: Background Information</H2>
+        <TextBlock>
+          To calculate your Social Security benefit, please input the
+          following dates.
+            </TextBlock>
+        <Card>
+          <H4>Birthdate</H4>
+          <StyledDatePicker
+            id="birthDatePicked"
+            placeholderText="Click to select a date"
+            selected={birthDate}
+            showYearDropdown
+            openToDate={
+              birthDate ||
+              dayjs()
+                .subtract(64, "year")
+                .toDate()
+            }
+            onChange={(value) =>
+              this.handleDateChange("birthDatePicked", value)
+            }
+          />
+        </Card>
+        {retireDateYear && (
+          <Card>
+            <H4>Retirement Age</H4>
+            <p>
+              Your Full Retirement Age (FRA) to collect Social Security
+                  Benefits is {fullRetirementAgeYearsOnly} years
+                  {fullRetirementAgeMonthsOnly
+                ? " and " + fullRetirementAgeMonthsOnly + " months "
+                : ""}{" "}
+                  old
+                  <a href="https://www.ssa.gov/OACT/ProgData/ar_drc.html">
+                <sup>1</sup>
+              </a>
+                  , which is in year {retireDateYear}.
+                  {/* TODO remove this and replace with a function that
                        checks the tables' isActualValue's*/
-                      retireDateYear>=2025 ? <WarningBox><label>This app may not
-                         be able to accurately calculate your results because
-                          it is still too many years away. Extrapolation based
-                           on the economy and Social Security&apos;s Trustees 
-                           Report may be added in a future version. 
-                           </label></WarningBox> : ""
-                      }</p>
-                  </Card>
-                  }
-            </div>
-         )
-    }
+                retireDateYear >= 2025 ? (
+                  <WarningBox>
+                    <label>
+                      This app may not be able to accurately calculate your
+                      results because it is still too many years away.
+                      Extrapolation based on the economy and Social
+                      Security&apos;s Trustees Report may be added in a future
+                      version.
+                      </label>
+                  </WarningBox>
+                ) : (
+                    ""
+                  )}
+            </p>
+          </Card>
+        )}
+      </div>
+    );
+  }
 }
 
 export default function Prescreen1aWrapper() {


### PR DESCRIPTION
closes #181
Added null value check for DatePicker. Now when the user deletes the date, the page will not crash but instead stay as the previously selected date.