### PR TITLE
Restore the text when there's no earnings record

### DIFF
--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -10,7 +10,6 @@ import UserStateManager from "../library/user-state-manager";
 import { breakPoints } from "../constants";
 
 const Wrapper = styled("div")`
-  display: block;
   overflow: hidden;
   position: relative;
   display: flex;
@@ -27,9 +26,11 @@ const Container = styled("div")`
   display: flex;
   font-family: 'Montserrat', sans-serif;
   min-height: 95vh;
-  max-width: ${breakPoints[2]};
   width: 100%;
   height: 100%;
+
+  /* The following line sets the max width of the design
+  breakPoint[5] is around 1440px so that creates whitespace at left */
   max-width: ${breakPoints[5]};
 `;
 

--- a/src/pages/prescreen-1b.tsx
+++ b/src/pages/prescreen-1b.tsx
@@ -11,16 +11,16 @@ import {
   LabelText,
   AnswerBox,
   Glossary,
-  WarningBox
+  WarningBox,
 } from "../components";
 import {
   UserState,
   EarningsEnum,
-  useUserState
+  useUserState,
 } from "../library/user-state-context";
 import {
   UserStateActions,
-  useUserStateActions
+  useUserStateActions,
 } from "../library/user-state-actions-context";
 
 export const SsaImage = styled("img")`
@@ -34,7 +34,7 @@ const CardGlossaryContainer = styled.div`
   justify-content: space-between;
   margin: auto 0;
 
-  @media (max-width: 767px){
+  @media (max-width: 767px) {
     display: block;
   }
 `;
@@ -48,11 +48,11 @@ const ContentContainer = styled.div`
 `;
 
 const TopQuestionAndTitle = styled.div`
-width: 70%;
-margin-bottom: 75px;
-@media (max-width: 767px){
-  width: 100%;
-}
+  width: 70%;
+  margin-bottom: 75px;
+  @media (max-width: 767px) {
+    width: 100%;
+  }
 `;
 
 const Link = styled.a`
@@ -62,8 +62,8 @@ const Link = styled.a`
 `;
 
 interface Prescreen1bProps {
-  userState: UserState
-  userStateActions: UserStateActions
+  userState: UserState;
+  userStateActions: UserStateActions;
 }
 
 class Prescreen1b extends React.Component<Prescreen1bProps> {
@@ -75,7 +75,7 @@ class Prescreen1b extends React.Component<Prescreen1bProps> {
 
   showFileUpload() {
     const {
-      userState: { haveEarnings, haveSSAAccount, earningsFormat }
+      userState: { haveEarnings, haveSSAAccount, earningsFormat },
     } = this.props;
     return (
       (haveEarnings === false && haveSSAAccount === true) ||
@@ -87,7 +87,7 @@ class Prescreen1b extends React.Component<Prescreen1bProps> {
 
   showManualTable() {
     const {
-      userState: { haveEarnings, earningsFormat }
+      userState: { haveEarnings, earningsFormat },
     } = this.props;
     return (
       haveEarnings === true &&
@@ -98,7 +98,7 @@ class Prescreen1b extends React.Component<Prescreen1bProps> {
 
   checkForBirthday = () => {
     const {
-      userState: { birthDate }
+      userState: { birthDate },
     } = this.props;
     if (birthDate === null) {
       return (
@@ -117,32 +117,56 @@ class Prescreen1b extends React.Component<Prescreen1bProps> {
   render() {
     const {
       userState: { haveEarnings, haveSSAAccount, earningsFormat },
-      userStateActions: { setHaveEarnings, setHaveSSAAccount, setEarningsFormat },
-    } = this.props
+      userStateActions: {
+        setHaveEarnings,
+        setHaveSSAAccount,
+        setEarningsFormat,
+      },
+    } = this.props;
     return (
       <React.Fragment>
-        <SEO title="Prescreen 1b" keywords={[`social security`, `government`, `retirement`]} />
+        <SEO
+          title="Prescreen 1b"
+          keywords={[`social security`, `government`, `retirement`]}
+        />
         <ContentContainer>
           <CardGlossaryContainer>
-            <TopQuestionAndTitle><H2>Step 2: Earnings</H2>
+            <TopQuestionAndTitle>
+              <H2>Step 2: Earnings</H2>
               <TextBlock>
-                Your Social Security retirement benefits are calculated based on your earnings in covered employment.
-            </TextBlock>
+                Your Social Security retirement benefits are calculated based on
+                your earnings in covered employment.
+              </TextBlock>
               <br />
               <TextBlock>
-                To calculate your Social Security retirement benefits, you will need a record of your earnings from Social Security.
-                Follow the steps below to get your earning record.
-            </TextBlock>
+                To calculate your Social Security retirement benefits, you will
+                need a record of your earnings from Social Security. Follow the
+                steps below to get your earning record.
+              </TextBlock>
               {this.checkForBirthday()}
 
               <Card>
-                <QuestionText>Do you have a copy of your earnings record?</QuestionText>
+                <QuestionText>
+                  Do you have a copy of your earnings record?
+                </QuestionText>
                 <AnswerBox>
-                  <RadioButton type="radio" name="haveEarnings" value="true" onChange={() => setHaveEarnings(true)} checked={haveEarnings === true} />
+                  <RadioButton
+                    type="radio"
+                    name="haveEarnings"
+                    value="true"
+                    onChange={() => setHaveEarnings(true)}
+                    checked={haveEarnings === true}
+                  />
                   <LabelText>Yes</LabelText>
                 </AnswerBox>
                 <AnswerBox>
-                  <RadioButton type="radio" name="haveEarnings" value="false" onChange={() => setHaveEarnings(false)} checked={haveEarnings === false} />
+                  <RadioButton
+                    type="radio"
+                    name="haveEarnings"
+                    value="false"
+                    onChange={() => setHaveEarnings(false)}
+                    checked={haveEarnings === false}
+                  />
                   <LabelText>No</LabelText>
                 </AnswerBox>
               </Card>
@@ -152,102 +176,194 @@ class Prescreen1b extends React.Component<Prescreen1bProps> {
               link="https://www.ssa.gov/myaccount/"
               linkText="Login or signup online for a MySocialSecurity using this link."
             >
-              MySocialSecurity is the Social Security Administrations online service. With a MySocialSecurity account , you can download a copy of your earnings record to use for this question.
-          </Glossary>
-
+              MySocialSecurity is the Social Security Administrations online
+              service. With a MySocialSecurity account , you can download a copy
+              of your earnings record to use for this question.
+            </Glossary>
           </CardGlossaryContainer>
 
-          {haveEarnings === true ?
+          {haveEarnings === true ? (
             <Card>
-              <QuestionText>What format is the copy of your earnings record?</QuestionText>
+              <QuestionText>
+                What format is the copy of your earnings record?
+              </QuestionText>
               <AnswerBox>
-                <RadioButton type="radio" name="earningsFormat" value={EarningsEnum.XML} onChange={() => setEarningsFormat(EarningsEnum.XML)} checked={earningsFormat === EarningsEnum.XML} />
+                <RadioButton
+                  type="radio"
+                  name="earningsFormat"
+                  value={EarningsEnum.XML}
+                  onChange={() => setEarningsFormat(EarningsEnum.XML)}
+                  checked={earningsFormat === EarningsEnum.XML}
+                />
                 <LabelText>XML file (MySocialSecurity)</LabelText>
               </AnswerBox>
               <AnswerBox>
-                <RadioButton type="radio" name="earningsFormat" value={EarningsEnum.PDF} onChange={() => setEarningsFormat(EarningsEnum.PDF)} checked={earningsFormat === EarningsEnum.PDF} />
+                <RadioButton
+                  type="radio"
+                  name="earningsFormat"
+                  value={EarningsEnum.PDF}
+                  onChange={() => setEarningsFormat(EarningsEnum.PDF)}
+                  checked={earningsFormat === EarningsEnum.PDF}
+                />
                 <LabelText>PDF (MySocialSecurity)</LabelText>
               </AnswerBox>
               <AnswerBox>
-                <RadioButton type="radio" name="earningsFormat" value={EarningsEnum.PDFPRINT} onChange={() => setEarningsFormat(EarningsEnum.PDFPRINT)} checked={earningsFormat === EarningsEnum.PDFPRINT} />
+                <RadioButton
+                  type="radio"
+                  name="earningsFormat"
+                  value={EarningsEnum.PDFPRINT}
+                  onChange={() => setEarningsFormat(EarningsEnum.PDFPRINT)}
+                  checked={earningsFormat === EarningsEnum.PDFPRINT}
+                />
                 <LabelText>PDF (scanned from print)</LabelText>
               </AnswerBox>
               <AnswerBox>
-                <RadioButton type="radio" name="earningsFormat" value={EarningsEnum.PAPER} onChange={() => setEarningsFormat(EarningsEnum.PAPER)} checked={earningsFormat === EarningsEnum.PAPER} />
+                <RadioButton
+                  type="radio"
+                  name="earningsFormat"
+                  value={EarningsEnum.PAPER}
+                  onChange={() => setEarningsFormat(EarningsEnum.PAPER)}
+                  checked={earningsFormat === EarningsEnum.PAPER}
+                />
                 <LabelText>Paper (mailed from SSA)</LabelText>
               </AnswerBox>
-            </Card> : null
-          }
+            </Card>
+          ) : null}
 
-          {haveEarnings === false ?
+          {haveEarnings === false ? (
             <Card>
-              <QuestionText>Do you have a MySocialSecurity account?</QuestionText>
+              <QuestionText>
+                Do you have a MySocialSecurity account?
+              </QuestionText>
               <AnswerBox>
-                <RadioButton type="radio" name="haveSSAAccount" value="true" onChange={() => setHaveSSAAccount(true)} checked={haveSSAAccount === true} />
+                <RadioButton
+                  type="radio"
+                  name="haveSSAAccount"
+                  value="true"
+                  onChange={() => setHaveSSAAccount(true)}
+                  checked={haveSSAAccount === true}
+                />
                 <LabelText>Yes</LabelText>
               </AnswerBox>
               <AnswerBox>
-                <RadioButton type="radio" name="haveSSAAccount" value="false" onChange={() => setHaveSSAAccount(false)} checked={haveSSAAccount === false} />
+                <RadioButton
+                  type="radio"
+                  name="haveSSAAccount"
+                  value="false"
+                  onChange={() => setHaveSSAAccount(false)}
+                  checked={haveSSAAccount === false}
+                />
                 <LabelText>No</LabelText>
               </AnswerBox>
-            </Card> : null
-          }
-
-          {this.showFileUpload() ?
+            </Card>
+          ) : null}
+          {haveEarnings === false && haveSSAAccount === true ? (
             <HowToContainer>
               <Card>
-                <TextBlock>
-                  Please upload your earnings record file
-                  </TextBlock>
+                <H2>HOW-TO</H2>
+                <h3>Download your earnings record from MySocialSecurity</h3>
+                <WarningBox>
+                  This how-to will show you how to download your personal
+                  Social Security information. Only follow these steps if
+                  you are using a private computer. If you only have access
+                  to a public computer - like those at a library, school, or
+                  computer lab - please click here to be shown instructions
+                  for requesting a physical copy of your earnings record in
+                  the mail.
+                </WarningBox>
+                <ul>
+                  <ol>1) Log in to your MySocialSecurity account</ol>
+                  <ol>
+                    2) Click on “Download Your Statement Data”, as seen in
+                    the red box in the photo below.
+                  </ol>
+                  <SsaImage src="https://user-images.githubusercontent.com/50156013/56998273-bcd78800-6b78-11e9-86b5-9db06d292a4c.jpg" />
+                  <ol>3) Save the XML file to your computer.</ol>
+                  <ol>4) Upload the XML file using the tool below.</ol>
+                </ul>
+              </Card>
+            </HowToContainer>
+          ) : null}
+          {this.showFileUpload() ? (
+            <HowToContainer>
+              <Card>
+                <TextBlock>Please upload your earnings record file</TextBlock>
                 <FileUpload manual={false} />
                 <TextBlock>
-                  Once you have uploaded your earnings record, click next and go forward.
+                  Once you have uploaded your earnings record, click next and go
+                  forward.
                 </TextBlock>
               </Card>
-            </HowToContainer> : null
-
-          }
+            </HowToContainer>
+          ) : null}
 
           {this.showManualTable() && (
             <div>
               <CardGlossaryContainer>
                 <Card>
                   <TextBlock>
-                    Please enter the “Taxed Social Security Earnings” amounts from your earnings record.
+                    Please enter the “Taxed Social Security Earnings” amounts
+                    from your earnings record.
                   </TextBlock>
-
                 </Card>
 
-                {
-                  this.showFileUpload() == true && <Glossary
-                    title="IMPORTED RECORDS"
-                  >
+                {this.showFileUpload() == true && (
+                  <Glossary title="IMPORTED RECORDS">
                     The values are imported from the file that you upload.
-                    Please review them for accuracy and correct any errors that you find.
+                    Please review them for accuracy and correct any errors that
+                    you find.
                   </Glossary>
-                }
-                {
-                  this.showManualTable() === true && <Glossary
-                    title="MANUAL RECORDS"
-                  >
-                    Please review the values so that the years match
-                    and correct any errors that you find. The first row
-                    may be a different year than on the paper
-                    document.
+                )}
+                {this.showManualTable() === true && (
+                  <Glossary title="MANUAL RECORDS">
+                    Please review the values so that the years match and correct
+                    any errors that you find. The first row may be a different
+                    year than on the paper document.
                   </Glossary>
-                }
+                )}
               </CardGlossaryContainer>
               <Card>
                 <FileUpload manual={true} />
               </Card>
             </div>
-          )
-          }
+          )}
 
+          {haveEarnings === false && haveSSAAccount === false ? (
+                <>
+                  <HowToContainer>
+                    <Card>
+                      <H2>HOW-TO</H2>
+                      <h3>
+                        Request a copy of your earnings report through the mail
+                      </h3>
+                      <WarningBox>
+                        We cannot estimate your WEP without a copy of your
+                        earnings record. The How-to’s linked below will tell you how to
+                        get your earnings record through the mail, or by signing
+                        up for a MySocialSecurity account online.
+                      </WarningBox>
+                    </Card>
+                  </HowToContainer>
+                  <HowToContainer>
+                    <Card>
+                      <H2>Browse to the HOW-TO</H2>
+                      <ul>
+                      <li><Link href="https://faq.ssa.gov/en-us/Topic/article/KA-01741">
+                        Read the guide.
+                      </Link></li>
+                      <li><Link href="https://secure.ssa.gov/RIL/SiView.action">
+                        Signup or login to your online account at
+                        MySocialSecurity
+                      </Link></li>
+                      </ul>
+                    </Card>
+                  </HowToContainer>
+                </>
+              ) : null}
         </ContentContainer>
       </React.Fragment>
-  )
-}
+    );
+  }
 }
 
 export default function Prescreen1bWrapper(): JSX.Element {


### PR DESCRIPTION
There was an issue recently introduced in a complicated rebase or merge I did which removed the cards that were returned. This PR puts them back.

<img width="443" alt="image" src="https://user-images.githubusercontent.com/283343/84348801-de7cae80-ab83-11ea-8e2e-ec3bf522b4d2.png">
