### PR TITLE
Follow on Draft pull request for issue #205

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/react-helmet": "^5.0.8",
     "@types/use-persisted-state": "^0.3.0",
     "babel-preset-gatsby": "^0.5.6",
-    "core-js": "^3.6.5",
+    "core-js": "3.6.5",
     "d3": "^5.11.0",
     "d3-format": "^1.4.3",
     "dayjs": "^1.8.15",
@@ -41,8 +41,7 @@
     "react-slick": "^0.25.2",
     "sharp": "^0.25.1",
     "typescript": "^3.3.4000",
-    "use-persisted-state": "^0.3.0",
-    "core-js": "3.6.5"
+    "use-persisted-state": "^0.3.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",

--- a/src/library/user-state-actions-context.tsx
+++ b/src/library/user-state-actions-context.tsx
@@ -15,6 +15,7 @@ export interface UserStateActions {
   setPensionAmount: (amount: number) => void
   setPensionDateAwarded: (date: Date) => void
   setUserProfile: (profile: UserProfile) => void
+  setPreferPiaUserCalc: (setPreferPiaUserCalc: boolean) => void
 }
 
 const UserStateActionsContext = React.createContext<UserStateActions | null>(null)

--- a/src/library/user-state-context.tsx
+++ b/src/library/user-state-context.tsx
@@ -47,6 +47,7 @@ export interface UserState {
   pensionAmount: number | null
   pensionDateAwarded: Date | null
   userProfile: UserProfile | null
+  preferPiaUserCalc: boolean | null
 }
 
 const UserStateContext = React.createContext<UserState | null>(null)

--- a/src/library/user-state-manager.tsx
+++ b/src/library/user-state-manager.tsx
@@ -23,6 +23,7 @@ const usePensionOrRetirementAccountState = createPersistedState('pensionOrRetire
 const usePensionAmountState = createPersistedState('pensionAmount', global.sessionStorage)
 const usePensionDateAwarded = createPersistedState('dateAwarded', global.sessionStorage)
 const useUserProfile = createPersistedState('UserProfile', global.sessionStorage);
+const usePreferPiaUserCalcState = createPersistedState('preferPiaUserCalcState', global.sessionStorage);
 
 
 // TODO The following should eventually be derived from the state values persisted to storage
@@ -58,6 +59,7 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
   const [pensionAmount, setPensionAmount] = usePensionAmountState<number | null>(null)
   const [pensionDateAwarded, setPensionDateAwarded] = usePensionDateAwarded<Date | null>(null)
   const [userProfile, setUserProfile] = useUserProfile<UserProfile | null>(null)
+  const [preferPiaUserCalc, setPreferPiaUserCalc] = usePreferPiaUserCalcState<boolean | null>(null)
 
   const userState: UserState = useMemo(() => ({
     birthDate: birthDate ? new Date(birthDate) : null,
@@ -75,7 +77,8 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
     pensionAmount,
     pensionDateAwarded,
     userProfile,
-  }), [birthDate, earnings, earningsFormat, haveEarnings, haveSSAAccount, isEmploymentCovered, pensionAmount, pensionDateAwarded, pensionOrRetirementAccount, retireDate, userProfile, year62])
+    preferPiaUserCalc,
+  }), [birthDate, earnings, earningsFormat, haveEarnings, haveSSAAccount, isEmploymentCovered, pensionAmount, pensionDateAwarded, pensionOrRetirementAccount, retireDate, userProfile, year62, preferPiaUserCalc])
 
   const actions: UserStateActions = useMemo(
     () => ({
@@ -91,6 +94,7 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
       setPensionAmount,
       setPensionDateAwarded,
       setUserProfile,
+      setPreferPiaUserCalc
     }),
     [
       setBirthDate,
@@ -105,6 +109,7 @@ export default function UserStateManager(props: UserStateManagerProps): JSX.Elem
       setRetireDate,
       setUserProfile,
       setYear62,
+      setPreferPiaUserCalc,
     ]
   );
 

--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { ButtonLink, SEO, H2, WarningBox, Glossary } from "../components";
+import { ButtonLink, SEO, H2, WarningBox, Glossary, AnswerBox, LabelText, RadioButton, QuestionText } from "../components";
 import * as ObsFuncs from "../library/observable-functions";
 import { fontSizes } from "../constants";
 import {
@@ -84,6 +84,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
         pensionOrRetirementAccount,
         pensionAmount,
         pensionDateAwarded,
+        preferPiaUserCalc,
       },
     } = this.props;
     if (!birthDate) throw Error();
@@ -124,7 +125,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
     }
 
     const userAIME = ObsFuncs.getAIMEFromEarnings(earnings, year62);
-    const piaUserCal = await finalCalculation(userDOB, userDOR, userPension, earnings);
+    const piaUserCalc = await finalCalculation(userDOB, userDOR, userPension, earnings);
     const userCalc = await ObsFuncs.finalCalculation(
       userDOB,
       userDOR,
@@ -133,8 +134,12 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
       userPension,
       userAIME
     );
-    //return piaUserCal;
+    
+    if (!preferPiaUserCalc) {
     return userCalc;
+    } else {
+    return piaUserCalc;
+    }
   };
 
   performCalc = async () => {
@@ -173,8 +178,9 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
   };
 
   render() {
-    const { userState } = this.props;
-    const { fullRetirementAge, userProfile } = userState;
+    const { userState, userStateActions} = this.props;
+    const { fullRetirementAge, userProfile, preferPiaUserCalc } = userState;
+    const { setPreferPiaUserCalc } = userStateActions;
 
     return (
       <React.Fragment>
@@ -201,43 +207,73 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
               </label>
             </WarningBox>
           ) : (
-            <Flex>
-              <Text>
-                Based on the information you provided, your retirement benefits
+              <Flex>
+
+                <QuestionText>
+                  Which calculator would you like to see results of?
+                  </QuestionText>
+
+                <AnswerBox>
+                  <RadioButton
+                    type="radio"
+                    name="preferPiaUserCalc"
+                    value="true"
+                    onChange={ () => setPreferPiaUserCalc(true)}
+                    checked={preferPiaUserCalc === true}                    
+                  />
+                  <LabelText>
+                    Official Social Security<br>
+                  </br> Calculator(AnyPIA)
+                  </LabelText>
+                </AnswerBox>
+
+                <AnswerBox>
+                  <RadioButton
+                    type="radio"
+                    name="preferPiaUserCalc"
+                    value="false"
+                    onChange={ () => setPreferPiaUserCalc(false)}
+                    checked={preferPiaUserCalc === false}
+                  />
+                  <LabelText>Our Calculator</LabelText>
+                </AnswerBox>
+
+                <Text>
+                  Based on the information you provided, your retirement benefits
                 will be calculated by Social Security as follows:{" "}
-              </Text>
-              <MonthlyBenefit
-                text={"Full Retirement Age"}
-                number={userProfile["MPB"]}
-              />
-              {this.state.testAge ? (
-                <>
-                  <Text>
-                    However, Social Security changes your monthly benefit amount
-                    if you begin to claim benefits before or after your full
-                    retirement age. Use the slider below to see how your planned
-                    date of retirement will affect your monthly benefit amount.
+                </Text>
+                <MonthlyBenefit
+                  text={"Full Retirement Age"}
+                  number={userProfile["MPB"]}
+                />
+                {this.state.testAge ? (
+                  <>
+                    <Text>
+                      However, Social Security changes your monthly benefit amount
+                      if you begin to claim benefits before or after your full
+                      retirement age. Use the slider below to see how your planned
+                      date of retirement will affect your monthly benefit amount.
                   </Text>
-                  <AgeSlider
-                    age={this.state.testAge}
-                    handleChange={this.handleRetireChange}
-                    fullRetirementAge={fullRetirementAge ?? undefined}
-                  />
-                  <MonthlyBenefit
-                    text={`age ${this.state.testAge}`}
-                    number={
-                      this.state.testProfile && this.state.testProfile["MPB"]
-                    }
-                  />
-                </>
-              ) : null}
-              <ButtonContainer>
-                <ButtonLink to="/print/" disabled={this.state.error !== null}>
-                  Print Results
+                    <AgeSlider
+                      age={this.state.testAge}
+                      handleChange={this.handleRetireChange}
+                      fullRetirementAge={fullRetirementAge ?? undefined}
+                    />
+                    <MonthlyBenefit
+                      text={`age ${this.state.testAge}`}
+                      number={
+                        this.state.testProfile && this.state.testProfile["MPB"]
+                      }
+                    />
+                  </>
+                ) : null}
+                <ButtonContainer>
+                  <ButtonLink to="/print/" disabled={this.state.error !== null}>
+                    Print Results
                 </ButtonLink>
-              </ButtonContainer>
-            </Flex>
-          )}
+                </ButtonContainer>
+              </Flex>
+            )}
         </ContentContainer>
         <Glossary
           title="FULL RETIREMENT AGE"

--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -219,7 +219,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
                     name="preferPiaUserCalc"
                     value="true"
                     onChange={ () => { 			setPreferPiaUserCalc(true);
-                     performCalc();
+                     this.performCalc();
                      }
                     }
                     checked={preferPiaUserCalc === true}                    

--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -177,10 +177,18 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
       });
   };
 
+  handlePreferPiaUserCalcChange = async () => {
+    const { setPreferPiaUserCalc} = this.props.userStateActions;
+
+    setPreferPiaUserCalc(preferPiaUserCalc.target.value);
+  
+    this.performCalc();
+  };
+
   render() {
-    const { userState, userStateActions} = this.props;
+    const { userState } = this.props;
     const { fullRetirementAge, userProfile, preferPiaUserCalc } = userState;
-    const { setPreferPiaUserCalc } = userStateActions;
+    
 
     return (
       <React.Fragment>
@@ -218,7 +226,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
                     type="radio"
                     name="preferPiaUserCalc"
                     value="true"
-                    onChange={ () => setPreferPiaUserCalc(true)}
+                    onChange={this.handlePreferPiaUserCalcChange}
                     checked={preferPiaUserCalc === true}                    
                   />
                   <LabelText>
@@ -232,7 +240,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
                     type="radio"
                     name="preferPiaUserCalc"
                     value="false"
-                    onChange={ () => setPreferPiaUserCalc(false)}
+                    onChange={this.handlePreferPiaUserCalcChange}
                     checked={preferPiaUserCalc === false}
                   />
                   <LabelText>Our Calculator</LabelText>

--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -218,7 +218,10 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
                     type="radio"
                     name="preferPiaUserCalc"
                     value="true"
-                    onChange={ () => setPreferPiaUserCalc(true)}
+                    onChange={ () => { 			setPreferPiaUserCalc(true);
+                     performCalc();
+                     }
+                    }
                     checked={preferPiaUserCalc === true}                    
                   />
                   <LabelText>


### PR DESCRIPTION
Follow on draft pull request for issue #205 

I added the setPreferPiaUserCalc function to the ComponentDidMount method on page 2. 

This now sets the default state for the preference to by that Standard PIA, since that works for all cases. The radio box will automatically be checked when the results page is loaded, and if the user chooses the "our calculator" radio, the calculation is automatically updated. 

 