### PR TITLE
Fix spelling error line 335 of screen-2 and Results table overrun on Print page

### DIFF
--- a/src/pages/print.tsx
+++ b/src/pages/print.tsx
@@ -37,6 +37,7 @@ export const ResultsCard = styled('div')`
     padding: 10px 15px;
     margin: 5px;
   }
+  overflow: scroll;
 `;
 
 const Row = styled.div`

--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -332,7 +332,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
                 >
                   You have a choice of calculator between the one based on our
                   research which does not calculate down to the month level and
-                  one very powerful offical one by the Social Security
+                  one very powerful official one by the Social Security
                   Administration. They may have been updated at different times.
                 </Glossary>
               </CardGlossaryContainer>


### PR DESCRIPTION
I fixed a spelling error on line 335 of screen-2 from "offical" to "official".

I noticed that children of the results cards containers on the print page are overrunning the results cards when the browser is scaled down. I set the style to be scroll on those elements.