### PR TITLE
Add desiredRetireDate to Screen2State and pass into performCalc

### DIFF
--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -73,6 +73,7 @@ interface Screen2Props {
 }
 
 interface Screen2State {
+  desiredRetireDate: Date | null;
   userWEP: boolean | null;
   error: string | null;
   testAge: number | null;
@@ -81,6 +82,7 @@ interface Screen2State {
 
 export class Screen2 extends React.Component<Screen2Props, Screen2State> {
   public state: Screen2State = {
+    desiredRetireDate: this.props.userState.retireDate,
     userWEP: null,
     error: null,
     testAge: null,
@@ -89,9 +91,12 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
 
   componentDidMount() {
     const { userState } = this.props;
-    const { preferPiaUserCalc } = userState;
+    const { preferPiaUserCalc, retireDate } = userState;
+    // const { setDesiredRetireDate } = userStateActions;
 
-    this.performCalc(preferPiaUserCalc).catch((err) => {
+    // setDesiredRetireDate(retireDate);
+
+    this.performCalc(retireDate, preferPiaUserCalc).catch((err) => {
       console.error("err", err);
       this.setState({
         error: "Missing Info",
@@ -168,7 +173,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
     }
   };
 
-  performCalc = async (preferPiaUserCalcValue: boolean | null) => {
+  performCalc = async (desiredRetireDateValue: Date, preferPiaUserCalcValue: boolean | null) => {
     const {
       userState: { birthDate, retireDate },
       userStateActions: { setUserProfile },
@@ -182,7 +187,8 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
     );
     setUserProfile(userCalc);
 
-    const yearsDiff = dayjs(retireDate).year() - dayjs(userDOB).year();
+    //yearsDiff is now calculated with the desiredRetireDateValue passed into performCalc.
+    const yearsDiff = dayjs(desiredRetireDateValue).year() - dayjs(userDOB).year();
     const clampedYearsDiff =
       yearsDiff < 62 ? 62 : yearsDiff > 70 ? 70 : yearsDiff;
     this.handleRetireChange(clampedYearsDiff, preferPiaUserCalcValue);
@@ -194,6 +200,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
   ) => {
     const {
       userState: { birthDate, preferPiaUserCalc },
+      // userStateActions: { setDesiredRetireDate },
     } = this.props;
     if (!birthDate) return;
 
@@ -213,8 +220,12 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
       userDOR,
       preferPiaUserCalcValueFastOrSlow
     );
+
+    // setDesiredRetireDate(userDOR);
+
     if (userCalc)
       this.setState({
+        desiredRetireDate: userDOR,
         testAge: age,
         testProfile: userCalc,
       });
@@ -302,7 +313,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
                     value="true"
                     onChange={() => {
                       setPreferPiaUserCalc(true);
-                      this.performCalc(true);
+                      this.performCalc(this.state.desiredRetireDate, true);
                     }}
                     checked={preferPiaUserCalc === true}
                   />
@@ -318,7 +329,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
                     value="false"
                     onChange={() => {
                       setPreferPiaUserCalc(false);
-                      this.performCalc(false);
+                      this.performCalc(this.state.desiredRetireDate, false);
                     }}
                     checked={preferPiaUserCalc === false}
                   />

--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -92,10 +92,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
   componentDidMount() {
     const { userState } = this.props;
     const { preferPiaUserCalc, retireDate } = userState;
-    // const { setDesiredRetireDate } = userStateActions;
-
-    // setDesiredRetireDate(retireDate);
-
+    
     this.performCalc(retireDate, preferPiaUserCalc).catch((err) => {
       console.error("err", err);
       this.setState({
@@ -187,7 +184,6 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
     );
     setUserProfile(userCalc);
 
-    //yearsDiff is now calculated with the desiredRetireDateValue passed into performCalc.
     const yearsDiff = dayjs(desiredRetireDateValue).year() - dayjs(userDOB).year();
     const clampedYearsDiff =
       yearsDiff < 62 ? 62 : yearsDiff > 70 ? 70 : yearsDiff;
@@ -200,7 +196,6 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
   ) => {
     const {
       userState: { birthDate, preferPiaUserCalc },
-      // userStateActions: { setDesiredRetireDate },
     } = this.props;
     if (!birthDate) return;
 
@@ -220,8 +215,6 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
       userDOR,
       preferPiaUserCalcValueFastOrSlow
     );
-
-    // setDesiredRetireDate(userDOR);
 
     if (userCalc)
       this.setState({


### PR DESCRIPTION
@thadk see my draft pull request to close #208 here. 

each time performCalc was being run, it was calling handleRetireChange and passing in diffYears. 

diffYears was set up such that it was always calculated based on the default retireDate (FRA), which was why it was always reverting back to the default FRA age. 

I added a desiredRetireDate to the Screen2State and set it equal to userDOR, so that the page could remember the date to pass into performCalc to rerun the diffYears calculation. 

Hopefully that makes sense.