### PR TITLE
Fix bug of slider calc not showing same MPB as top calc on screen-2

### DIFF
--- a/src/pages/screen-2.tsx
+++ b/src/pages/screen-2.tsx
@@ -175,7 +175,7 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
     console.log("performCalc:",userCalc);
     setUserProfile(userCalc);
 
-    const yearsDiff = dayjs(desiredRetireDateValue).diff((dayjs(userDOB)),'year', true);
+    const yearsDiff = dayjs(desiredRetireDateValue).diff(dayjs(userDOB),'year', true);
     
     const clampedYearsDiff =
       yearsDiff < 62 ? 62 : yearsDiff > 70 ? 70 : yearsDiff;
@@ -198,8 +198,9 @@ export class Screen2 extends React.Component<Screen2Props, Screen2State> {
     const adjustMonthsFor62yo = age === 62 ? 1 : 0;
 
     const userDOB = birthDate.toLocaleDateString("en-US");
+    const retireMonth = age * 12;
     const userDOR = dayjs(userDOB)
-      .add(age, "year")
+      .add(retireMonth, "month")
       .add(adjustMonthsFor62yo, "month")
       .toDate();
 


### PR DESCRIPTION
@thadk see the pull request to fix the bug where the calculation for MPB for the slider showing a different number than the top calculation for MPB. 

The fix was to convert the desired retirement age to months, because the dayjs add() method does not support decimals. The date of retirement is now based on the month.

We were associating this with issue #215 